### PR TITLE
Fix the syntax highlight of rust

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,8 +13,15 @@ RUN tlmgr install \
       accsupp \
       tcolorbox \
       luatexja
-RUN apk add python3 py3-pip py3-pygments
+RUN apk add python3 py3-pip 
 RUN ln -s /usr/bin/python3 /usr/bin/python
+RUN wget --no-check-certificate -O pygments-rs https://github.com/Alignof/pygments-rs/tarball/master \
+    && mkdir pygments \
+    && tar xzf pygments-rs -C pygments --strip-components 1 \
+    && cd pygments \
+    && python setup.py install \
+    && cd .. \
+    && rm -rf pygments*
 RUN pip3 install pandocfilters
 RUN wget -O - https://github.com/lierdakil/pandoc-crossref/releases/download/v0.3.12.1a/pandoc-crossref-Linux.tar.xz | \
   tar Jxf - \

--- a/listings-setup.tex
+++ b/listings-setup.tex
@@ -7,7 +7,6 @@
 \usepackage{accsupp}
 \usepackage[cache=false]{minted}
 \usepackage[most, theorems, listings, minted, breakable]{tcolorbox}
-\usemintedstyle{monokai}
 
 \definecolor{bg}{HTML}{333333}
 \definecolor{line}{HTML}{000000}
@@ -26,6 +25,7 @@
     theorem={Listing}{listings}{#3}{},
      fonttitle=\scriptsize\bfseries,
      listing engine=minted,
+     minted style=custom,
      minted language=#2,
      colback=bg,
      minted options={%


### PR DESCRIPTION
- Replace py3-pygments to my customized pygments for rust
- Change highlight style (monokai -> my custom style)